### PR TITLE
Update to angular 1.5.11 and patternfly 3.18.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-key-value-editor",
   "description": "A simple UI for editing key-value pairs",
-  "version": "2.9.3",
+  "version": "3.0.0",
   "main": [
     "dist/angular-key-value-editor.css",
     "dist/angular-key-value-editor.js",
@@ -21,11 +21,11 @@
     "tests"
   ],
   "dependencies": {
-    "patternfly": "~3.10.0",
+    "patternfly": "~3.18.1",
     "ng-sortable": "~1.3.4"
   },
   "devDependencies": {
-    "angular": "~1.3.20",
+    "angular": "~1.5.11",
     "lodash": "~4.13.1",
     "angular-object-diff": "~1.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-key-value-editor",
-  "version": "2.9.3",
+  "version": "3.0.0",
   "description": "A simple UI for editing key-value pairs",
   "main": "index.js",
   "scripts": {
@@ -43,6 +43,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-safari-launcher": "^1.0.0",
-    "karma-spec-reporter": "0.0.26"
+    "karma-spec-reporter": "0.0.26",
+    "jasmine-core": "^2.5.2"
   }
 }

--- a/src/less/angular-key-value-editor.less
+++ b/src/less/angular-key-value-editor.less
@@ -1,5 +1,5 @@
 // Angular Key Value Editor styles
-@import "../../bower_components/patternfly/less/variables.less";
+@import "../../bower_components/patternfly/dist/less/variables.less";
 
 @as-sortable-dragging-opacity:                             .65;
 @as-sortable-item-button-width:                            ((@as-sortable-item-icon-padding * 2) + @as-sortable-item-icon-font-size - 1);


### PR DESCRIPTION
Hi,
Updating this component to latest angular 1.5.x and patternfly 3.x.

- all unit tests pass
- manually ran through many test pages
- could not get e2e testing running on my system: "WebDriverError: unknown error: Chrome version must be >= 53.0.2785.0" I'm using Chrome on Linux v50.0.2661.86 :-(

Thanks,
- Dave